### PR TITLE
Simplify MovieslistViewModelTests

### DIFF
--- a/MoviesApp/Domain/Model/Movie.swift
+++ b/MoviesApp/Domain/Model/Movie.swift
@@ -1,4 +1,3 @@
-
 import Foundation
 
 struct Movie: Decodable {
@@ -10,10 +9,4 @@ struct Movie: Decodable {
         case ano = "release_date"
         case caminhoIMG = "poster_path"
     }
-}
-
-struct MoviePage {
-    let page: Int
-    let totalPage: Int
-    let moviesPageArray: [Movie]
 }

--- a/MoviesApp/Presentation/Scenes/MoviesList/MoviesListViewModel.swift
+++ b/MoviesApp/Presentation/Scenes/MoviesList/MoviesListViewModel.swift
@@ -1,27 +1,22 @@
 final class MoviesListViewModel {
-
     var movies: Observable<[Movie]> = Observable([])
     private let lastPage = 500
-    private var paginaAtual: Int = 1
+    private(set) var paginaAtual: Int = 1
     private let moviesRepository: MoviesRepositoryProtocol
-    
+
     init(repository: MoviesRepositoryProtocol = MoviesRepository()) {
         self.moviesRepository = repository
     }
-    
-    func fetchMovies(pagina: Int, completionHandler: (() -> Void)? = nil) {
-        if pagina > lastPage {
-            completionHandler?()
-        } else {
-            moviesRepository.getMovies(pagina: pagina) { [weak self] movies in
-                self?.movies.value += movies
-                completionHandler?()
-            }
+
+    func fetchMovies(pagina: Int) {
+        guard pagina <= lastPage else { return }
+        moviesRepository.getMovies(pagina: pagina) { [weak self] movies in
+            self?.movies.value += movies
         }
     }
-    
-    func nextPage(completionHandler: (() -> Void)? = nil) {
+
+    func nextPage() {
         paginaAtual += 1
-        fetchMovies(pagina: paginaAtual, completionHandler: completionHandler)
+        fetchMovies(pagina: paginaAtual)
     }
 }

--- a/MoviesAppTests/Data/Mocks/MockMoviesRepository.swift
+++ b/MoviesAppTests/Data/Mocks/MockMoviesRepository.swift
@@ -1,9 +1,12 @@
 @testable import MoviesApp
+import XCTest
 
 class MockMoviesRepository: MoviesRepositoryProtocol {
     var mockMovies: [Movie] = []
+    var expectation: XCTestExpectation?
     
     func getMovies(pagina: Int, completionHandler: @escaping ([Movie]) -> Void) {
+        expectation?.fulfill()
         completionHandler(mockMovies)
     }
 }

--- a/MoviesAppTests/Presentation/ViewModel/MoviesListViewModelTests.swift
+++ b/MoviesAppTests/Presentation/ViewModel/MoviesListViewModelTests.swift
@@ -9,24 +9,18 @@ import XCTest
 @testable import MoviesApp
 
 final class MoviesListViewModelTests: XCTestCase {
-
-    var viewModel: MoviesListViewModel!
-    var mockRepository: MockMoviesRepository!
-    let moviesPages: [MoviePage] = [
-        MoviePage(page: 1,
-                  totalPage: 2,
-                  moviesPageArray: [
-                    Movie(titulo: "Superman", ano: "2020", caminhoIMG: ""),
-                    Movie(titulo: "Batman", ano: "2018", caminhoIMG: ""),
-                    Movie(titulo: "Aquaman", ano: "2022", caminhoIMG: "")
-                  ]),
-        MoviePage(page: 2,
-                  totalPage: 2,
-                  moviesPageArray: [
-                    Movie(titulo: "Superman 2", ano: "2022", caminhoIMG: ""),
-                    Movie(titulo: "Batman 2", ano: "2020", caminhoIMG: ""),
-                    Movie(titulo: "Aquaman 2", ano: "2024", caminhoIMG: "")
-                  ])
+    private var viewModel: MoviesListViewModel!
+    private var mockRepository: MockMoviesRepository!
+    
+    private let page1: [Movie] = [
+        Movie(titulo: "Superman", ano: "2020", caminhoIMG: ""),
+        Movie(titulo: "Batman", ano: "2018", caminhoIMG: ""),
+        Movie(titulo: "Aquaman", ano: "2022", caminhoIMG: "")
+    ]
+    private let page2 = [
+        Movie(titulo: "Superman 2", ano: "2022", caminhoIMG: ""),
+        Movie(titulo: "Batman 2", ano: "2020", caminhoIMG: ""),
+        Movie(titulo: "Aquaman 2", ano: "2024", caminhoIMG: "")
     ]
     
     override func setUp()  {
@@ -40,47 +34,39 @@ final class MoviesListViewModelTests: XCTestCase {
     }
     
     func testIfFirstPageLoads()  {
-        //Prepare
-        mockRepository.mockMovies = moviesPages[0].moviesPageArray
-        let expectation = expectation(description: "Wait for movies update")
+        // Prepare
+        mockRepository.mockMovies = page1
+        mockRepository.expectation = expectation(description: "Single page load")
         
-        //Execute
-        viewModel.fetchMovies(pagina: 1) {
-            expectation.fulfill()
-        }
-        
-        waitForExpectations(timeout: 5, handler: nil)
-        
-        //Assert
-        XCTAssertEqual(viewModel.movies.value.count, 3)
-        XCTAssertEqual(viewModel.movies.value, moviesPages[0].moviesPageArray)
+        // Execute
+        viewModel.fetchMovies(pagina: 1)
+        waitForExpectations(timeout: 5)
+
+        // Assert
+        XCTAssertEqual(viewModel.movies.value.count, page1.count)
+        XCTAssertEqual(viewModel.movies.value, page1)
     }
     
     func testIfTwoPagesAreRequestedThenViewModelContainsTwoPages()  {
-        //Prepare
-        mockRepository.mockMovies = moviesPages[0].moviesPageArray
-        let exp = expectation(description: "Wait movie update")
-        
-        //Execute
-        viewModel.fetchMovies(pagina: 1) {
-            exp.fulfill()
-        }
-        waitForExpectations(timeout: 5, handler: nil)
-        
-        //Prepare
-        mockRepository.mockMovies = moviesPages[1].moviesPageArray
-        let exp2 = expectation(description: "Wait for Page update")
-        
-        //Execute
-        viewModel.nextPage() {
-            exp2.fulfill()
-        }
-        
-        waitForExpectations(timeout: 5, handler: nil)
-        
-        //Assert
-        XCTAssertEqual(viewModel.movies.value.count, 6)
-        XCTAssertEqual(viewModel.movies.value, moviesPages[0].moviesPageArray + moviesPages[1].moviesPageArray)
+        // Prepare
+        mockRepository.mockMovies = page1
+        mockRepository.expectation = expectation(description: "Fist page load")
+
+        // Execute
+        viewModel.fetchMovies(pagina: 1)
+        waitForExpectations(timeout: 5)
+    
+        mockRepository.mockMovies = page2
+        mockRepository.expectation = expectation(description: "Second page load")
+
+        viewModel.nextPage()
+        waitForExpectations(timeout: 5)
+
+        // Assert
+        let allPages = page1 + page2
+        XCTAssertEqual(viewModel.movies.value.count, allPages.count)
+        XCTAssertEqual(viewModel.movies.value, allPages)
+        XCTAssertEqual(viewModel.paginaAtual, 2)
     }
 }
 


### PR DESCRIPTION
Instead of fulfilling expectation using completion handlers coming from the ViewModel, I moved that responsability to MockMoviesRepository.

Also deleted the model MoviePage because it was more confusing than helful.

The test also now checks for the currente page after moving to the second page